### PR TITLE
Add runner input parameter

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,10 +21,14 @@ on:
         description: "Optional: Path to Dockerfile"
         type: "string"
         required: false
+      runner:
+        description: "GitHub runner for workflow (Default: ubuntu-latest)"
+        type: "string"
+        default: "ubuntu-latest"
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -27,6 +27,10 @@ on:
         description: "Optional: Path to Dockerfile"
         type: "string"
         required: false
+      runner:
+        description: "GitHub runner for workflow (Default: ubuntu-latest)"
+        type: "string"
+        default: "ubuntu-latest"
 
 jobs:
   docker:

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -28,13 +28,13 @@ on:
         type: "string"
         required: false
       runner:
-        description: "GitHub runner for workflow (Default: ubuntu-latest)"
+        description: "GitHub runner for workflow (Default: ubuntu-latest-16-cores)"
         type: "string"
-        default: "ubuntu-latest"
+        default: "ubuntu-latest-16-cores"
 
 jobs:
   docker:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ inputs.runner }}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Adding input parameters for runner to use for `docker` and `dockerhub` workflows. Runner allows users of workflow to specify larger runners for docker builds that require more resources like carma-msgs. The default value for the `docker` workflow is `ubuntu-latest` which matches what was previously the hardcoded runner and the default value for `docker-hub` was `ubuntu-latest-16-cores` which matches what was previously the hardcoded runner. The argument for having a different default value I assume is that we want `dockerhub` to execute as fast as possible since it produces and pushes images we use and `docker` is less critical since it is only checking whether the current image is buildable. 
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
[ARC-77](https://usdot-carma.atlassian.net/browse/ARC-77)
<!-- e.g. CAR-123 -->

## Motivation and Context
Allow configurable runner for image builds that require more resources
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
carma-msgs CI (https://github.com/usdot-fhwa-stol/carma-msgs/actions/runs/8896959246)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[ARC-77]: https://usdot-carma.atlassian.net/browse/ARC-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ