### PR TITLE
Update cpp-module-build.yml

### DIFF
--- a/.github/workflows/cpp-module-build.yml
+++ b/.github/workflows/cpp-module-build.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Publish deb artifacts
         uses: usdot-fhwa-stol/actions/deb-s3-upload@main
         with:
-          artifact-name: deb-packages-${{ inputs.build-architecture }}
+          artifact-name: deb-packages-${{ inputs.build-architecture }}-${{ inputs.build-image-tag }}
           aws-access-key-id: ${{ secrets.aws-access-key-id }}
           aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
           bucket-codename: ${{ inputs.bucket-codename }}

--- a/.github/workflows/cpp-module-build.yml
+++ b/.github/workflows/cpp-module-build.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Upload deb artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: deb-packages-${{ inputs.build-architecture }}
+          name: deb-packages-${{ inputs.build-architecture }}-${{ inputs.build-image-tag }}
           path: |
             build*/_packages/*.deb
             ${{ inputs.working-folder }}/build*/_packages/*.deb


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
The cpp-module-build workflow is one of the workflows define in the https://github.com/usdot-fhwa-stol/actions repository. It is responsible for building simple C++ libraries into Debian packages and pushing those packages to our STOL apt S3 repository.

Currently is has a bug that when called in a matrix (a sequence of builds of the same library for different processor architectures and linux distributions) the Debian package generated from one build configuration may be incorrectly pushed to our repository as a different configuration. For example a Debian package build on ubuntu jammy (22) maybe be pushed as a package for ubuntu focal. This causes dependency issues when attempting to pull down the pushed package.

From prior investigation I suspect the actions/upload-artifact and actions/download-artifact are the likely culprit. When running only a single configuration in the matrix the build works fine but when running multiple each download seems to grab a random uploaded artificat. Better naming convention of uploaded artifacts and download artifacts may eliminate this problem

Previously this bug was manifesting itself in projects that depend on the [carma-time library](https://github.com/usdot-fhwa-stol/carma-time-lib) when they attempted to pull in this dependency they would get an error like 
```
 The following packages have unmet dependencies:
9.481  carma-clock-1 : Depends: libc6 (>= 2.32) but 2.27-3ubuntu1.6 is to be installed
9.481                  Depends: libgcc-s1 (>= 3.0) but it is not installable
9.481                  Depends: libstdc++6 (>= 12) but 8.4.0-1ubuntu1~18.04 is to be installed
```
This error indicates that the debian package installed requires a higher version of gcc or std than that ubuntu distribution has available. Since we build these Debian packages on the ubuntu distribution they are for, this seems that we may have been pushing Debian packages build on one distribution to the incorrect STOL apt S3 distribution folder. Looking at the workflow I realized that upload and download actions push the packages with naming specific only to architecture and not to ubuntu distribution so it is likely that conccurent uploads with matching names overwrite causing incorrect Debian packages to be pushed to the S3 bucket.  

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
[CS-55
](https://usdot-carma.atlassian.net/browse/CS-55)<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
This was tested by making this branch and calling its action with in this branch of carma-time lib (https://github.com/usdot-fhwa-stol/carma-time-lib/tree/fix-cpp-module-build). The debian packages pushed by this workflow on the feature branch fixed the docker builds for the dependent project carma-streets (https://github.com/usdot-fhwa-stol/carma-streets/actions/runs/9288876307/job/25561380337)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
