### PR TITLE
Support docker-org-and-tag to support multiple suffices

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,14 @@ on:
         description: "GitHub runner for workflow (Default: ubuntu-latest)"
         type: "string"
         default: "ubuntu-latest"
+      tag_name_suffix:
+        description: "Optional: Custom docker image tag name suffix to be appended, defaults to empty string"
+        type: "string"
+        required: false
+      replace_suffix:
+        description: "Optional: True if last part of the docker_tag needs to be replaced with given tag_name_suffix"
+        type: "boolean"
+        required: false
 
 jobs:
   docker:
@@ -36,7 +44,10 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Determine Docker organization and tag
         id: docker-org-and-tag
-        uses: usdot-fhwa-stol/actions/docker-org-and-tag@main
+        uses: usdot-fhwa-stol/actions/docker-org-and-tag@arc-199-support-different-suffix
+        with:
+          docker_tag_suffix: ${{inputs.tag_name_suffix}}
+          replace_suffix: ${{inputs.replace_suffix}}
       - name: Determine base branch
         id: determine-base-branch
         run: |

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -35,6 +35,10 @@ on:
         description: "Optional: Custom docker image tag name suffix to be appended, defaults to empty string"
         type: "string"
         required: false
+      replace_suffix:
+        description: "Optional: True if last part of the docker_tag needs to be replaced with given tag_name_suffix"
+        type: "boolean"
+        required: false
       runner:
         description: "GitHub runner for workflow (Default: ubuntu-latest-16-cores)"
         type: "string"
@@ -73,7 +77,7 @@ jobs:
         uses: usdot-fhwa-stol/actions/docker-org-and-tag@main
         with:
           docker_tag_suffix: ${{inputs.tag_name_suffix}}
-
+          replace_suffix: ${{inputs.replace_suffix}}
       - name: Determine base branch
         id: determine-base-branch
         run: |

--- a/docker-org-and-tag/action.yml
+++ b/docker-org-and-tag/action.yml
@@ -78,7 +78,13 @@ runs:
         
         # Append the docker_tag_suffix if it's not empty
         if [ -n "$DOCKER_TAG_SUFFIX" ]; then
-            docker_image_tag="${docker_image_tag}-${DOCKER_TAG_SUFFIX}"
+            if [[ "$docker_image_tag" == *"develop-humble" ]]; then
+                # Replace the last occurrence of -humble with the suffix
+                # NOTE: ARC-248 This change only lasts until develop-humble is merged into develop
+                docker_image_tag="${docker_image_tag%-humble}-${DOCKER_TAG_SUFFIX}"
+            else
+                docker_image_tag="${docker_image_tag}-${DOCKER_TAG_SUFFIX}"
+            fi
         fi
         
         echo "docker_image_tag=${docker_image_tag}" >> $GITHUB_OUTPUT

--- a/docker-org-and-tag/action.yml
+++ b/docker-org-and-tag/action.yml
@@ -35,6 +35,7 @@ runs:
       env:
         PULL_REQUEST: ${{ github.event_name }}
         DOCKER_TAG_SUFFIX: ${{ inputs.docker_tag_suffix }}
+        REPLACE_SUFFIX: ${{ inputs.replace_suffix }}
       run: |
         docker_image_tag=""
         if [[ "$PULL_REQUEST" == "pull_request" ]]; then
@@ -78,12 +79,12 @@ runs:
         
         # Append the docker_tag_suffix if it's not empty
         if [ -n "$DOCKER_TAG_SUFFIX" ]; then
-            if [[ "$docker_image_tag" == *"develop-humble" ]]; then
-                # Replace the last occurrence of -humble with the suffix
-                # NOTE: ARC-248 This change only lasts until develop-humble is merged into develop
-                docker_image_tag="${docker_image_tag%-humble}-${DOCKER_TAG_SUFFIX}"
+            if [ "$REPLACE_SUFFIX" = "true" ]; then
+                # Extract the portion before and after the last "-"
+                base_tag="${docker_image_tag%-*}"  # Part before the last "-"
+                docker_image_tag="${base_tag}-${DOCKER_TAG_SUFFIX}"  # Replace suffix with custom suffix
             else
-                docker_image_tag="${docker_image_tag}-${DOCKER_TAG_SUFFIX}"
+                docker_image_tag="${docker_image_tag}-${DOCKER_TAG_SUFFIX}"  # Append suffix if no "-"
             fi
         fi
         


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
We need a special detection for branch `develop-humble` (or more general) because we need to apply different docker tag suffix to images. For example, I am trying to create docker image with tags:
- usdotfhwastoldev/carma-ssc-interface-wrapper:develop-noetic
- usdotfhwastoldev/carma-ssc-interface-wrapper:develop-humble
which also requires respectively:
- usdotfhwastoldev/carma-base:develop-noetic
- usdotfhwastoldev/carma-base:develop-humble

PRs to develop-humble has been working fine up until now because it just picked the referenced branch name as its docker-tag which created `usdotfhwastoldev/carma-image:develop-humble` anyways. However, this doesn't work for (only during when develop-humble branch is in use) these different suffix images because it will create develop-humble either way.

We do have suffix applying functionality (if we specify suffix such as humble and noetic) but it only works for official branches such as develop, release/*, or carma-system etc, which is the long term solution.

However if it is a custom branch such as develop-humble, the resulting docker_tag will end up being develop-humble-humble or develop-humble-noetic. So we need to detect this custom branch.

In order to detect it, I just added a boolean to see if it the suffix of the referenced branch need to be replaced or not.
Since I assume we will follow the same convention such as develop-jazzy in the future, it will be come develop-noetic and develop-jazzy.

<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
ARC-199
<!-- e.g. CAR-123 -->

## Motivation and Context
Needed to create different images for carma-ssc-interface-wrapper. See above.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested with custom branch name first to see if it is detecting correctly:
Noetic Action: https://github.com/usdot-fhwa-stol/carma-ssc-interface-wrapper/actions/runs/12716632778/job/35451734390
Humble Action: https://github.com/usdot-fhwa-stol/carma-ssc-interface-wrapper/actions/runs/12716632778/job/35451734390
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
