### PR TITLE
Allow for specifying component name for build-cpp-module

### DIFF
--- a/.github/workflows/cpp-module-build.yml
+++ b/.github/workflows/cpp-module-build.yml
@@ -22,6 +22,10 @@ on:
         required: false
         type: string
         default: ''
+      component-name:
+        description: 'The component of the APT repository. This should be equivalent to ubuntu distribution code name that this artifact supports'
+        required: true
+        type: string
       working-folder:
         description: 'Working folder to build in'
         type: string
@@ -90,3 +94,4 @@ jobs:
           aws-access-key-id: ${{ secrets.aws-access-key-id }}
           aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
           bucket-codename: ${{ inputs.bucket-codename }}
+          component-name: ${{ inputs.component-name }}


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Add component name as input parameter for cpp-module-build workflow for debian package builds. This parameter should be set to the ubuntu distribution codename the package is compatible with. This means that debian packages built using this workflow will be under **branch-name** **ubuntu-distro-codename** in the apt repository
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->
ARC-275
## Motivation and Context
Fix CI for debian package builds 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
