### PR TITLE
Use remove_suffix

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -102,10 +102,17 @@ jobs:
           ORIGINAL_TAG="${{ steps.docker-org-and-tag.outputs.docker_image_tag }}"
           echo "Original tag: $ORIGINAL_TAG"
           
-          # Remove everything after the first dash (if a dash exists)
+          # Remove everything after the last dash (if a dash exists)
           if [[ "$ORIGINAL_TAG" == *-* ]]; then
             BASE_TAG="${ORIGINAL_TAG%%-*}"
-            REMOVED_SUFFIX="${ORIGINAL_TAG#*-}"
+            for part in $(echo "$ORIGINAL_TAG" | tr "-" "\n" | head -n -1); do
+              if [ "$BASE_TAG" = "${ORIGINAL_TAG%%-*}" ]; then
+                BASE_TAG="$part"
+              else
+                BASE_TAG="$BASE_TAG-$part"
+              fi
+            done
+            REMOVED_SUFFIX="${ORIGINAL_TAG##*-}"
             echo "Removed suffix: -$REMOVED_SUFFIX from tag"
             echo "Docker image output tag after suffix removal: $BASE_TAG"
             echo "processed_tag=$BASE_TAG" >> $GITHUB_OUTPUT
@@ -115,6 +122,11 @@ jobs:
             echo "::warning::Keeping original tag: $ORIGINAL_TAG"
             echo "processed_tag=$ORIGINAL_TAG" >> $GITHUB_OUTPUT
           fi
+                
+      - name: Check for conflicting suffix options
+        if: ${{ inputs.remove_suffix == true && inputs.replace_suffix == true }}
+        run: |
+          echo "::warning::Both replace_suffix and remove_suffix are enabled. remove_suffix will override replace_suffix and remove the suffix entirely."
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -32,11 +32,15 @@ on:
         type: "string"
         required: false
       tag_name_suffix:
-        description: "Optional: Custom docker image tag name suffix to be appended, defaults to empty string"
+        description: "Optional: Custom docker image tag name suffix to be appended (applies to both base image and output image unless remove_suffix is used), defaults to empty string"
         type: "string"
         required: false
       replace_suffix:
-        description: "Optional: True if last part of the docker_tag needs to be replaced with given tag_name_suffix"
+        description: "Optional: True if last part of the docker_tag needs to be replaced with given tag_name_suffix (applies to both base image and output image unless remove_suffix is used)"
+        type: "boolean"
+        required: false
+      remove_suffix:
+        description: "Optional: True if suffix should be removed from the docker_tag (e.g., 'develop-humble' becomes 'develop')"
         type: "boolean"
         required: false
       runner:
@@ -78,6 +82,7 @@ jobs:
         with:
           docker_tag_suffix: ${{inputs.tag_name_suffix}}
           replace_suffix: ${{inputs.replace_suffix}}
+          remove_suffix: ${{inputs.remove_suffix}}
       - name: Determine base branch
         id: determine-base-branch
         run: |

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -120,7 +120,7 @@ jobs:
             VERSION=${{ steps.build-metadata.outputs.version }}
             TOKEN=${{ secrets.GH_PAT }}
             DOCKER_ORG=${{ steps.docker-org-and-tag.outputs.docker_organization }}
-            DOCKER_TAG=${{ inputs.remove_suffix == true && steps.process-docker-tag.outputs.processed_tag || steps.docker-org-and-tag.outputs.docker_image_tag }}
+            DOCKER_TAG=${{ steps.docker-org-and-tag.outputs.docker_image_tag }}
             GIT_BRANCH=${{ steps.determine-base-branch.outputs.git_branch }}
             ACCESS_ID=${{ secrets.ACCESS_ID }}
             SECRET_KEY=${{ secrets.SECRET_KEY }}

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -100,12 +100,19 @@ jobs:
         run: |
           # Extract the tag from the original output
           ORIGINAL_TAG="${{ steps.docker-org-and-tag.outputs.docker_image_tag }}"
+          echo "Original tag: $ORIGINAL_TAG"
+          
           # Remove everything after the first dash (if a dash exists)
           if [[ "$ORIGINAL_TAG" == *-* ]]; then
             BASE_TAG="${ORIGINAL_TAG%%-*}"
+            REMOVED_SUFFIX="${ORIGINAL_TAG#*-}"
+            echo "Removed suffix: -$REMOVED_SUFFIX from tag"
+            echo "Docker image output tag after suffix removal: $BASE_TAG"
             echo "processed_tag=$BASE_TAG" >> $GITHUB_OUTPUT
           else
             # If no dash exists, keep the original tag
+            echo "::warning::No suffix to remove - tag doesn't contain a dash where it was expected"
+            echo "::warning::Keeping original tag: $ORIGINAL_TAG"
             echo "processed_tag=$ORIGINAL_TAG" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -82,7 +82,6 @@ jobs:
         with:
           docker_tag_suffix: ${{inputs.tag_name_suffix}}
           replace_suffix: ${{inputs.replace_suffix}}
-          remove_suffix: ${{inputs.remove_suffix}}
       - name: Determine base branch
         id: determine-base-branch
         run: |
@@ -94,19 +93,34 @@ jobs:
       - name: Determine Build Metadata
         id: build-metadata
         uses: usdot-fhwa-stol/actions/docker-build-metadata@main
+        
+      - name: Process Docker tag (handle remove_suffix)
+        id: process-docker-tag
+        if: ${{ inputs.remove_suffix == true }}
+        run: |
+          # Extract the tag from the original output
+          ORIGINAL_TAG="${{ steps.docker-org-and-tag.outputs.docker_image_tag }}"
+          # Remove everything after the first dash (if a dash exists)
+          if [[ "$ORIGINAL_TAG" == *-* ]]; then
+            BASE_TAG="${ORIGINAL_TAG%%-*}"
+            echo "processed_tag=$BASE_TAG" >> $GITHUB_OUTPUT
+          else
+            # If no dash exists, keep the original tag
+            echo "processed_tag=$ORIGINAL_TAG" >> $GITHUB_OUTPUT
+          fi
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: ${{ steps.docker-org-and-tag.outputs.docker_organization }}/${{ inputs.image_name || github.event.repository.name }}:${{ steps.docker-org-and-tag.outputs.docker_image_tag }}
+          tags: ${{ steps.docker-org-and-tag.outputs.docker_organization }}/${{ inputs.image_name || github.event.repository.name }}:${{ inputs.remove_suffix == true && steps.process-docker-tag.outputs.processed_tag || steps.docker-org-and-tag.outputs.docker_image_tag }}
           build-args: |
             BUILD_DATE=${{ steps.build-metadata.outputs.build_date }}
             VCS_REF=${{ steps.build-metadata.outputs.vcs_ref }}
             VERSION=${{ steps.build-metadata.outputs.version }}
             TOKEN=${{ secrets.GH_PAT }}
             DOCKER_ORG=${{ steps.docker-org-and-tag.outputs.docker_organization }}
-            DOCKER_TAG=${{ steps.docker-org-and-tag.outputs.docker_image_tag }}
+            DOCKER_TAG=${{ inputs.remove_suffix == true && steps.process-docker-tag.outputs.processed_tag || steps.docker-org-and-tag.outputs.docker_image_tag }}
             GIT_BRANCH=${{ steps.determine-base-branch.outputs.git_branch }}
             ACCESS_ID=${{ secrets.ACCESS_ID }}
             SECRET_KEY=${{ secrets.SECRET_KEY }}

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -104,14 +104,8 @@ jobs:
           
           # Remove everything after the last dash (if a dash exists)
           if [[ "$ORIGINAL_TAG" == *-* ]]; then
-            BASE_TAG="${ORIGINAL_TAG%%-*}"
-            for part in $(echo "$ORIGINAL_TAG" | tr "-" "\n" | head -n -1); do
-              if [ "$BASE_TAG" = "${ORIGINAL_TAG%%-*}" ]; then
-                BASE_TAG="$part"
-              else
-                BASE_TAG="$BASE_TAG-$part"
-              fi
-            done
+            # Extract the part before the last dash (removes suffix after last dash)
+            BASE_TAG="${ORIGINAL_TAG%-*}"
             REMOVED_SUFFIX="${ORIGINAL_TAG##*-}"
             echo "Removed suffix: -$REMOVED_SUFFIX from tag"
             echo "Docker image output tag after suffix removal: $BASE_TAG"

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -94,8 +94,8 @@ jobs:
         id: build-metadata
         uses: usdot-fhwa-stol/actions/docker-build-metadata@main
         
-      - name: Process Docker tag (handle remove_suffix)
-        id: process-docker-tag
+      - name: Process Suffix in Output Docker Image tag (handle remove_suffix)
+        id: process-suffix-in-output-docker-tag
         if: ${{ inputs.remove_suffix == true }}
         run: |
           # Extract the tag from the original output
@@ -113,7 +113,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: ${{ steps.docker-org-and-tag.outputs.docker_organization }}/${{ inputs.image_name || github.event.repository.name }}:${{ inputs.remove_suffix == true && steps.process-docker-tag.outputs.processed_tag || steps.docker-org-and-tag.outputs.docker_image_tag }}
+          tags: ${{ steps.docker-org-and-tag.outputs.docker_organization }}/${{ inputs.image_name || github.event.repository.name }}:${{ inputs.remove_suffix == true && steps.process-suffix-in-output-docker-tag.outputs.processed_tag || steps.docker-org-and-tag.outputs.docker_image_tag }}
           build-args: |
             BUILD_DATE=${{ steps.build-metadata.outputs.build_date }}
             VCS_REF=${{ steps.build-metadata.outputs.vcs_ref }}

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -105,8 +105,14 @@ jobs:
           # Remove everything after the last dash (if a dash exists)
           if [[ "$ORIGINAL_TAG" == *-* ]]; then
             # Extract the part before the last dash (removes suffix after last dash)
+            # ${variable%-pattern} removes the shortest match of pattern from the end
+            # Example: "develop-1-2-3-humble" becomes "develop"
             BASE_TAG="${ORIGINAL_TAG%-*}"
+            
+            # ${variable##pattern} removes the longest match of pattern from the beginning
+            # Example: for "develop-1-2-3-humble" this extracts just "humble"
             REMOVED_SUFFIX="${ORIGINAL_TAG##*-}"
+
             echo "Removed suffix: -$REMOVED_SUFFIX from tag"
             echo "Docker image output tag after suffix removal: $BASE_TAG"
             echo "processed_tag=$BASE_TAG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Some images may require certain suffix, but resulting image shouldn't because there is only 1 version. This enables that option.
For example:
carma-base:develop-humble (also can be carma-base:develop-noetic)
but images that build on it just has develop:
autoware.ai:develop
carma-platform:develop
<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
ARC-248
<!-- e.g. CAR-123 -->

## Motivation and Context
Merging develop-humble branch to develop
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
testing now
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
