### PR TITLE
Add resuable rm suffix workflow

### DIFF
--- a/remove-suffix/action.yml
+++ b/remove-suffix/action.yml
@@ -1,0 +1,23 @@
+name: 'Remove suffix from Docker tag'
+description: 'Outputs the tag without the part after the last dash'
+inputs:
+  tag:
+    description: 'Original tag (e.g. stingray-humble)'
+    required: true
+outputs:
+  processed_tag:
+    description: 'Tag with suffix removed (e.g. stingray)'
+    value: ${{ steps.strip.outputs.result }}
+runs:
+  using: composite
+  steps:
+    - id: strip
+      shell: bash
+      run: |
+        ORIGINAL="${{ inputs.tag }}"
+        if [[ "$ORIGINAL" == *-* ]]; then
+          CLEAN="${ORIGINAL%-*}"
+        else
+          CLEAN="$ORIGINAL"
+        fi
+        echo "result=$CLEAN" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
Adds a reusable workflow that strips the suffix from Docker image tags.
For example, if docker-org-and-tag produces stingray-humble, the new step removes -humble and pushes the image with the tag stingray.

## Description

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
