### PR TITLE
Fix Image Tag Mismatches for Downstream Docker Builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,7 +64,7 @@ jobs:
           build-args: |
             TOKEN=${{ secrets.GH_PAT }}
             DOCKER_ORG=${{ steps.docker-org-and-tag.outputs.docker_organization }}
-            DOCKER_TAG=${{ steps.docker-org-and-tag.outputs.docker_image_tag }}
+            DOCKER_TAG=${{ steps.docker-org-and-tag.outputs.docker_pull_tag }}
             GIT_BRANCH=${{ steps.determine-base-branch.outputs.git_branch}}
             ACCESS_ID=${{ secrets.ACCESS_ID}}
             SECRET_KEY=${{ secrets.SECRET_KEY}}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,7 +44,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Determine Docker organization and tag
         id: docker-org-and-tag
-        uses: usdot-fhwa-stol/actions/docker-org-and-tag@fix/master_builds
+        uses: usdot-fhwa-stol/actions/docker-org-and-tag@main
         with:
           docker_tag_suffix: ${{inputs.tag_name_suffix}}
           replace_suffix: ${{inputs.replace_suffix}}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,7 +44,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Determine Docker organization and tag
         id: docker-org-and-tag
-        uses: usdot-fhwa-stol/actions/docker-org-and-tag@main
+        uses: usdot-fhwa-stol/actions/docker-org-and-tag@fix/master_builds
         with:
           docker_tag_suffix: ${{inputs.tag_name_suffix}}
           replace_suffix: ${{inputs.replace_suffix}}

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Determine Docker organization and tag
         id: docker-org-and-tag
-        uses: usdot-fhwa-stol/actions/docker-org-and-tag@main
+        uses: usdot-fhwa-stol/actions/docker-org-and-tag@fix/master_builds
         with:
           docker_tag_suffix: ${{inputs.tag_name_suffix}}
           replace_suffix: ${{inputs.replace_suffix}}

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -47,10 +47,6 @@ on:
         description: "GitHub runner for workflow (Default: ubuntu-latest-16-cores)"
         type: "string"
         default: "ubuntu-latest-16-cores"
-      enable_dual_tag_push:
-        description: "Set to true if alias tags like master-humble should be pushed"
-        type: "boolean"
-        required: false
 
 jobs:
   docker:
@@ -143,21 +139,9 @@ jobs:
             VERSION=${{ steps.build-metadata.outputs.version }}
             TOKEN=${{ secrets.GH_PAT }}
             DOCKER_ORG=${{ steps.docker-org-and-tag.outputs.docker_organization }}
-            DOCKER_TAG=${{ steps.docker-org-and-tag.outputs.docker_image_tag }}
+            DOCKER_TAG=${{ steps.docker-org-and-tag.outputs.docker_pull_tag }}
             GIT_BRANCH=${{ steps.determine-base-branch.outputs.git_branch }}
             ACCESS_ID=${{ secrets.ACCESS_ID }}
             SECRET_KEY=${{ secrets.SECRET_KEY }}
           context: ${{ inputs.context }}
           file: ${{ inputs.file }}
-      
-      - name: Push alias tag
-        if: ${{ steps.docker-org-and-tag.outputs.docker_image_tag_alias != '' && inputs.enable_dual_tag_push == true }}
-        run: |
-          IMAGE=${{ steps.docker-org-and-tag.outputs.docker_organization }}/${{ inputs.image_name || github.event.repository.name }}
-          SRC=${{ steps.docker-org-and-tag.outputs.docker_image_tag }}
-          DST=${{ steps.docker-org-and-tag.outputs.docker_image_tag_alias }}
-          echo "Pulling image to tag alias: $IMAGE:$SRC"
-          docker pull $IMAGE:$SRC
-          echo "Pushing alias tag from $SRC to $DST for image $IMAGE"
-          docker tag  $IMAGE:$SRC  $IMAGE:$DST
-          docker push $IMAGE:$DST

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -47,6 +47,10 @@ on:
         description: "GitHub runner for workflow (Default: ubuntu-latest-16-cores)"
         type: "string"
         default: "ubuntu-latest-16-cores"
+      enable_dual_tag_push:
+        description: "Set to true if alias tags like master-humble should be pushed"
+        type: "boolean"
+        required: false
 
 jobs:
   docker:
@@ -145,3 +149,14 @@ jobs:
             SECRET_KEY=${{ secrets.SECRET_KEY }}
           context: ${{ inputs.context }}
           file: ${{ inputs.file }}
+      
+      - name: Push alias tag
+        if: ${{ steps.docker-org-and-tag.outputs.docker_image_tag_alias != '' && inputs.enable_dual_tag_push == true }}
+        run: |
+          IMAGE=${{ steps.docker-org-and-tag.outputs.docker_organization }}/${{ inputs.image_name || github.event.repository.name }}
+          SRC=${{ steps.docker-org-and-tag.outputs.docker_image_tag }}
+          DST=${{ steps.docker-org-and-tag.outputs.docker_image_tag_alias }}
+
+          echo "Pushing alias tag from $SRC to $DST for image $IMAGE"
+          docker tag  $IMAGE:$SRC  $IMAGE:$DST
+          docker push $IMAGE:$DST

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -156,7 +156,8 @@ jobs:
           IMAGE=${{ steps.docker-org-and-tag.outputs.docker_organization }}/${{ inputs.image_name || github.event.repository.name }}
           SRC=${{ steps.docker-org-and-tag.outputs.docker_image_tag }}
           DST=${{ steps.docker-org-and-tag.outputs.docker_image_tag_alias }}
-
+          echo "Pulling image to tag alias: $IMAGE:$SRC"
+          docker pull $IMAGE:$SRC
           echo "Pushing alias tag from $SRC to $DST for image $IMAGE"
           docker tag  $IMAGE:$SRC  $IMAGE:$DST
           docker push $IMAGE:$DST

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Determine Docker organization and tag
         id: docker-org-and-tag
-        uses: usdot-fhwa-stol/actions/docker-org-and-tag@fix/master_builds
+        uses: usdot-fhwa-stol/actions/docker-org-and-tag@main
         with:
           docker_tag_suffix: ${{inputs.tag_name_suffix}}
           replace_suffix: ${{inputs.replace_suffix}}

--- a/docker-org-and-tag/action.yml
+++ b/docker-org-and-tag/action.yml
@@ -16,6 +16,10 @@ outputs:
   docker_image_tag:
     description: 'Docker image tag'
     value: ${{ steps.docker-org-and-tag.outputs.docker_image_tag }}
+  docker_image_tag_alias:
+    description: 'Alias tag (master-*  → carma-master-*)'
+    value: ${{ steps.docker-org-and-tag.outputs.docker_image_tag_alias }}
+
 runs:
   using: 'composite'
   steps:
@@ -107,7 +111,17 @@ runs:
                 docker_image_tag="${docker_image_tag}-${DOCKER_TAG_SUFFIX}"  # Append suffix if no "-"
             fi
         fi
-        
+
+        # create carma-master tag for master-* when using docker_image_tag_alias in repositories.
+        if [[ "$docker_image_tag" == master-* ]]; then
+            echo "docker_image_tag_alias=${docker_image_tag/master-/carma-master-}" >> $GITHUB_OUTPUT
+        fi
+
+        # Create master (with or without suffix) for carma-master (matching suffix/none) when using docker_image_tag_alias.
+        if [[ "$docker_image_tag" == carma-master* ]]; then
+            echo "docker_image_tag_alias=${docker_image_tag/carma-master/master}" >> $GITHUB_OUTPUT
+        fi
+
         echo "docker_image_tag=${docker_image_tag}" >> $GITHUB_OUTPUT
         
     - name: Echo Docker Organization and Docker Image tag

--- a/docker-org-and-tag/action.yml
+++ b/docker-org-and-tag/action.yml
@@ -111,16 +111,32 @@ runs:
             fi
         fi
         
-        if [[ "$docker_image_tag" == carma-master* ]]; then
-            docker_pull_tag="${docker_image_tag/#carma-/}"
-        elif [[ "$docker_image_tag" == master* ]]; then
-            docker_pull_tag="carma-${docker_image_tag}"
-        else
+        REPO_NAME="${GITHUB_REPOSITORY##*/}"
+          # For autoware.ai repository:
+          # If docker_image_tag starts with "carma-master", strip the "carma-" prefix to pull from carma-base:master-*
+          # Example: carma-master-humble → master-humble
+        if [[ "$REPO_NAME" == "autoware.ai" ]]; then     
+          
+          if [[ "$docker_image_tag" == carma-master* ]]; then
+            docker_pull_tag="${docker_image_tag/#carma-/}"   # carma-master* → master*
+          else
             docker_pull_tag="$docker_image_tag"
-        fi
-        echo "docker_pull_tag=${docker_pull_tag}" >> "$GITHUB_OUTPUT"
+          fi
         
-        echo "docker_image_tag=${docker_image_tag}" >> $GITHUB_OUTPUT
+        elif [[ "$docker_image_tag" == master ]]; then  
+          # For downstream repositories on master branch:
+          # If they use autoware.ai as the base image, pull autoware.ai:carma-master.
+          # If they use carma-base as the base image, pull carma-base:master-humble or master-noetic (based on suffix, no change needed here).   
+          if [[ "$BASE_IMAGE" == "autoware.ai" ]]; then
+            docker_pull_tag="carma-master"   # Pull autoware.ai:carma-master
+          else
+            docker_pull_tag="$docker_image_tag" 
+          fi
+        else
+          docker_pull_tag="$docker_image_tag" # every other individual branches like  develop, release…) 
+        fi
+        echo "docker_pull_tag=${docker_pull_tag}" >>"$GITHUB_OUTPUT"
+        echo "docker_image_tag=${docker_image_tag}" >>"$GITHUB_OUTPUT"
         
     - name: Echo Docker Organization and Docker Image tag
       shell: bash

--- a/docker-org-and-tag/action.yml
+++ b/docker-org-and-tag/action.yml
@@ -16,10 +16,9 @@ outputs:
   docker_image_tag:
     description: 'Docker image tag'
     value: ${{ steps.docker-org-and-tag.outputs.docker_image_tag }}
-  docker_image_tag_alias:
-    description: 'Alias tag (master-*  → carma-master-*)'
-    value: ${{ steps.docker-org-and-tag.outputs.docker_image_tag_alias }}
-
+  docker_pull_tag:
+    description: 'Pull base images with tags as master or carma-master'
+    value: ${{ steps.docker-org-and-tag.outputs.docker_pull_tag }}
 runs:
   using: 'composite'
   steps:
@@ -111,17 +110,16 @@ runs:
                 docker_image_tag="${docker_image_tag}-${DOCKER_TAG_SUFFIX}"  # Append suffix if no "-"
             fi
         fi
-
-        # create carma-master tag for master-* when using docker_image_tag_alias in repositories.
-        if [[ "$docker_image_tag" == master-* ]]; then
-            echo "docker_image_tag_alias=${docker_image_tag/master-/carma-master-}" >> $GITHUB_OUTPUT
-        fi
-
-        # Create master (with or without suffix) for carma-master (matching suffix/none) when using docker_image_tag_alias.
+        
         if [[ "$docker_image_tag" == carma-master* ]]; then
-            echo "docker_image_tag_alias=${docker_image_tag/carma-master/master}" >> $GITHUB_OUTPUT
+            docker_pull_tag="${docker_image_tag/#carma-/}"
+        elif [[ "$docker_image_tag" == master* ]]; then
+            docker_pull_tag="carma-${docker_image_tag}"
+        else
+            docker_pull_tag="$docker_image_tag"
         fi
-
+        echo "docker_pull_tag=${docker_pull_tag}" >> "$GITHUB_OUTPUT"
+        
         echo "docker_image_tag=${docker_image_tag}" >> $GITHUB_OUTPUT
         
     - name: Echo Docker Organization and Docker Image tag


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR updates the docker-org-and-tag and dockerhub.yml workflows to handle docker pulls where downstream repositories depend on Docker image tags that do not match their own branch name conventions. Added a new docker_pull_tag: for correct base image tag used for pulling image in downsteam repo's for example as below:


If the downstream repository is on master:

    If it's using autoware.ai, it pulls from: autoware.ai:carma-master

    If it's using carma-base, it pulls from:

        carma-base:master-humble or

        carma-base:master-noetic
        depending on the suffix logic

If the downstream repository is on carma-master:

    If it's using carma-base, it pulls from:

        carma-base:master-humble or

        carma-base:master-noetic

## Description

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

[OMDO-35](https://usdot-carma.atlassian.net/browse/OMDO-35)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
This has be tested on fork repo by creating fake release branches and triggered workflow via push, pull request and tagging.


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[OMDO-35]: https://usdot-carma.atlassian.net/browse/OMDO-35?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ